### PR TITLE
Fix 'A PWM object already exists for this GPIO channel' exception

### DIFF
--- a/octoprint_enclosure/__init__.py
+++ b/octoprint_enclosure/__init__.py
@@ -1572,6 +1572,7 @@ class EnclosurePlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplateP
                 pin = self.to_int(gpio_out_pwm['gpio_pin'])
                 self._logger.info("Setting GPIO pin %s as PWM", pin)
                 for pwm in (pwm_dict for pwm_dict in self.pwm_instances if pin in pwm_dict):
+                    pwm_dict[pin].stop()
                     self.pwm_instances.remove(pwm)
                 self.clear_channel(pin)
                 GPIO.setup(pin, GPIO.OUT)


### PR DESCRIPTION
Fix for https://github.com/vitormhenrique/OctoPrint-Enclosure/issues/335 and https://github.com/vitormhenrique/OctoPrint-Enclosure/issues/236